### PR TITLE
API Pagination

### DIFF
--- a/okydoky/app.py
+++ b/okydoky/app.py
@@ -97,7 +97,7 @@ def ensure_login():
         repo_name = current_app.config['REPOSITORY']
         # user repos
         response = urllib2.urlopen(
-            'https://api.github.com/user/repos?access_token=' +
+            'https://api.github.com/user/repos?per_page=100&access_token=' +
             login
         )
         repo_dicts = json.load(response)
@@ -107,7 +107,7 @@ def ensure_login():
         auth = repo_name in repos
         # org repos
         if not auth:
-            url = 'https://api.github.com/orgs/{0}/repos?access_token={1}'
+            url = 'https://api.github.com/orgs/{0}/repos?per_page=100&access_token={1}'
             try:
                 response = urllib2.urlopen(
                     url.format(repo_name.split('/', 1)[0], login)


### PR DESCRIPTION
The GitHub API list responses are paginated. We had an issue where the documentation repo was on page 2, and was never seen by Okydoky. This is a quick fix, but ideally we should have an iterator abstraction for repos. We actually solved this for events in another project:

`GitHub` is a `requests.session` wrapper. We’re also getting good mileage out of URLObject from @zacharyvoase. Comments?

``` python
def org_events(page="1"):
    """Yield organization events for a user. """

    with GitHub() as github:
        url = (
            api_url
            .relative(
                '/users/{}/events/orgs/{}'
                .format(session['user']['login'], github_org))
            .add_query_params(dict(page=page))
        )
        response = github.get(url)

    response.raise_for_status()

    for event in response.json:
        yield event

    links = parse_link_header(response.headers.get('Link'))
    if 'next' in links:
        next = URL(links['next']).query.dict['page']
        if next == page:
            raise StopIteration  # Raise exception?
        for event in org_events(page=next):
            yield event

    raise StopIteration
```
